### PR TITLE
Switch the base docker image to the official one from sonar source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM newtmitch/sonar-scanner:4.0.0-alpine
+FROM sonarsource/sonar-scanner-cli:4.3
 
 LABEL "com.github.actions.name"="SonarQube Scan"
 LABEL "com.github.actions.description"="Scan your code with SonarQube Scanner to detect bugs, vulnerabilities and code smells in more than 25 programming languages."
 LABEL "com.github.actions.icon"="check"
 LABEL "com.github.actions.color"="green"
 
-LABEL version="0.0.1"
+LABEL version="0.0.3"
 LABEL repository="https://github.com/kitabisa/sonarqube-action"
 LABEL homepage="https://kitabisa.github.io"
 LABEL maintainer="dwisiswant0"

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 name: 'SonarQube Scanner'
 description: 'Scan your code with SonarQube Scanner to detect bugs, vulnerabilities and code smells in more than 25 programming languages.'
-author: 'Dwi Siswanto / Marc Berchtold'
+author: 'Dwi Siswanto / Marc Berchtold / Jeffrey Haskovec'
 branding:
   icon: 'check'
   color: 'green'


### PR DESCRIPTION
This changes the docker container from the one specified to the official container published by sonar-source. This seems safer from a security standpoint to use official images from sonarsource rather than 3rd party images.